### PR TITLE
Add Swift Package Manager support

### DIFF
--- a/FriendlyCaptcha/Classes/FriendlyCaptchaWidgetConstants.swift
+++ b/FriendlyCaptcha/Classes/FriendlyCaptchaWidgetConstants.swift
@@ -5,6 +5,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+import Foundation
+
 /// Constants for the different states of the FriendlyCaptcha widget.
 @objc
 public enum WidgetState: Int, Codable {

--- a/FriendlyCaptcha/Classes/FriendlyCaptchaWidgetEvent.swift
+++ b/FriendlyCaptcha/Classes/FriendlyCaptchaWidgetEvent.swift
@@ -5,6 +5,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+import Foundation
+
 /// Event that gets dispatched when the widget is completed.
 ///
 /// This happens when the user's browser has successfully passed the captcha challenge.

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+internal let package = Package(
+    name: "FriendlyCaptcha",
+    platforms: [.iOS(.v12)],
+    products: [
+        .library(
+            name: "FriendlyCaptcha",
+            targets: ["FriendlyCaptcha"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "FriendlyCaptcha",
+            path: "FriendlyCaptcha/Classes"
+        ),
+    ],
+    swiftLanguageModes: [.v5]
+)
+

--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ Add the following line to your Cartfile:
 github "FriendlyCaptcha/friendly-captcha-ios" ~> 1.0.1
 ```
 
+### Swift Package Manager
+
+Add the following package repository URL to your dependencies:
+
+```
+dependencies: [
+    .package(url: "https://github.com/riendlyCaptcha/friendly-captcha-ios.git", .upToNextMinor(from: "1.0.1"))
+]
+```
+
 ## Documentation
 
 The full API reference for the SDK is available [here](https://friendlycaptcha.github.io/friendly-captcha-ios/documentation/friendlycaptcha).


### PR DESCRIPTION
This PR adds a Swift Package Manager manifest to the SDK repository, allowing consumers who no longer use the deprecated CocoaPods or Carthage to integrate the SDK directly into their iOS projects without manual framework management.

If you’d like to test this PR and see how it works in Xcode, just add my branch to your `Package.swift`:

```swift
.package(
    url: "https://github.com/ivan-gaydamakin/friendly-captcha-ios.git",
    branch: "add_spm_support"
)
```
