### PR TITLE
Use do...catch for JSON parsing instead of try!

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - FriendlyCaptcha (1.0.3)
+  - FriendlyCaptcha (1.0.4)
   - Nimble (10.0.0)
   - Quick (5.0.1)
 
@@ -18,7 +18,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  FriendlyCaptcha: 30622a9ab93ffde0c328758e712cf62829939dbe
+  FriendlyCaptcha: 25e9a7d7d4f03fc42e00487f72a19c59a0a4c5a1
   Nimble: 5316ef81a170ce87baf72dd961f22f89a602ff84
   Quick: 749aa754fd1e7d984f2000fe051e18a3a9809179
 

--- a/Example/Pods/Local Podspecs/FriendlyCaptcha.podspec.json
+++ b/Example/Pods/Local Podspecs/FriendlyCaptcha.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "FriendlyCaptcha",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "summary": "An iOS SDK for FriendlyCaptcha, a privacy-first bot protection service.",
   "description": "Friendly Captcha is a service that protects websites from bots and abuse\nin a privacy-friendly and accessible way. This SDK is the official\niOS integration for Friendly Captcha.",
   "homepage": "https://github.com/FriendlyCaptcha/friendly-captcha-ios",
@@ -17,9 +17,9 @@
   },
   "source": {
     "git": "https://github.com/FriendlyCaptcha/friendly-captcha-ios.git",
-    "tag": "1.0.3"
+    "tag": "1.0.4"
   },
-  "readme": "https://raw.githubusercontent.com/FriendlyCaptcha/friendly-captcha-ios/refs/tags/1.0.3/README.md",
+  "readme": "https://raw.githubusercontent.com/FriendlyCaptcha/friendly-captcha-ios/refs/tags/1.0.4/README.md",
   "platforms": {
     "ios": "9.0"
   },

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - FriendlyCaptcha (1.0.3)
+  - FriendlyCaptcha (1.0.4)
   - Nimble (10.0.0)
   - Quick (5.0.1)
 
@@ -18,7 +18,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  FriendlyCaptcha: 30622a9ab93ffde0c328758e712cf62829939dbe
+  FriendlyCaptcha: 25e9a7d7d4f03fc42e00487f72a19c59a0a4c5a1
   Nimble: 5316ef81a170ce87baf72dd961f22f89a602ff84
   Quick: 749aa754fd1e7d984f2000fe051e18a3a9809179
 

--- a/Example/Pods/Target Support Files/FriendlyCaptcha/FriendlyCaptcha-Info.plist
+++ b/Example/Pods/Target Support Files/FriendlyCaptcha/FriendlyCaptcha-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>1.0.3</string>
+  <string>1.0.4</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -73,6 +73,63 @@ class FriendlyCaptchaSpec: QuickSpec {
             QuickSpec.current.waitForExpectations(timeout: 60)
         }
 
+        it("triggers error callback for unknown message type") {
+            let expectation = QuickSpec.current.expectation(description: "unknown message type error")
+            handle.onError { event in
+                expect(event.error.code) == .other
+                expect(event.error.detail).to(contain("Unknown message type"))
+                expectation.fulfill()
+            }
+            handle.onStateChange { event in
+                if event.state == .unactivated {
+                    let webView = handle.Widget().view as! WKWebView
+                    webView.evaluateJavaScript(
+                        "window.webkit.messageHandlers.bus.postMessage({type: 'unknown_test_type', data: {}})",
+                        completionHandler: nil
+                    )
+                }
+            }
+            QuickSpec.current.waitForExpectations(timeout: 60)
+        }
+
+        it("triggers error callback when message data cannot be decoded") {
+            let expectation = QuickSpec.current.expectation(description: "unable to decode to message")
+            handle.onError { event in
+                expect(event.error.code) == .other
+                expect(event.error.detail).to(contain("Failed to decode"))
+                expectation.fulfill()
+            }
+            handle.onStateChange { event in
+                if event.state == .unactivated {
+                    let webView = handle.Widget().view as! WKWebView
+                    webView.evaluateJavaScript(
+                        "window.webkit.messageHandlers.bus.postMessage({type: 'complete', data: {invalid: true}})",
+                        completionHandler: nil
+                    )
+                }
+            }
+            QuickSpec.current.waitForExpectations(timeout: 60)
+        }
+
+        it("triggers error callback when message data is not valid json") {
+            let expectation = QuickSpec.current.expectation(description: "unable to deserialize json error")
+            handle.onError { event in
+                expect(event.error.code) == .other
+                expect(event.error.detail).to(contain("Failed to decode"))
+                expectation.fulfill()
+            }
+            handle.onStateChange { event in
+                if event.state == .unactivated {
+                    let webView = handle.Widget().view as! WKWebView
+                    webView.evaluateJavaScript(
+                        "window.webkit.messageHandlers.bus.postMessage({type: 'complete', data: 'invalid'})",
+                        completionHandler: nil
+                    )
+                }
+            }
+            QuickSpec.current.waitForExpectations(timeout: 60)
+        }
+
         it("can be destroyed") {
             expect(handle.Widget().viewIfLoaded).to(beAnInstanceOf(WKWebView.self))
             let expectation = QuickSpec.current.expectation(description: "destroy")

--- a/FriendlyCaptcha.podspec
+++ b/FriendlyCaptcha.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'FriendlyCaptcha'
-  s.version          = '1.0.3'
+  s.version          = '1.0.4'
   s.summary          = 'An iOS SDK for FriendlyCaptcha, a privacy-first bot protection service.'
 
   s.description      = <<-DESC

--- a/FriendlyCaptcha/Classes/FriendlyCaptcha.swift
+++ b/FriendlyCaptcha/Classes/FriendlyCaptcha.swift
@@ -9,7 +9,7 @@ import UIKit
 @preconcurrency import WebKit
 import Foundation
 
-let VERSION = "1.0.3"
+let VERSION = "1.0.4"
 
 /// A class for interacting with the Friendly Captcha widget.
 ///
@@ -318,21 +318,25 @@ class WidgetViewController: UIViewController, WKScriptMessageHandler, WKNavigati
            let body = message.body as? [String: Any],
            let type = body["type"] as? String,
            let jsonData = try? JSONSerialization.data(withJSONObject: body["data"] as Any) {
-            switch type {
-            case "complete":
-                let message = try! JSONDecoder().decode(WidgetCompleteEvent.self, from: jsonData)
-                handleComplete(message)
-            case "error":
-                let message = try! JSONDecoder().decode(WidgetErrorEvent.self, from: jsonData)
-                handleError(message)
-            case "expire":
-                let message = try! JSONDecoder().decode(WidgetExpireEvent.self, from: jsonData)
-                handleExpire(message)
-            case "statechange":
-                let message = try! JSONDecoder().decode(WidgetStateChangeEvent.self, from: jsonData)
-                handleStateChange(message)
-            default:
-                print("Unknown message type", body)
+            do {
+                switch type {
+                case "complete":
+                    let message = try JSONDecoder().decode(WidgetCompleteEvent.self, from: jsonData)
+                    handleComplete(message)
+                case "error":
+                    let message = try JSONDecoder().decode(WidgetErrorEvent.self, from: jsonData)
+                    handleError(message)
+                case "expire":
+                    let message = try JSONDecoder().decode(WidgetExpireEvent.self, from: jsonData)
+                    handleExpire(message)
+                case "statechange":
+                    let message = try JSONDecoder().decode(WidgetStateChangeEvent.self, from: jsonData)
+                    handleStateChange(message)
+                default:
+                    print("FriendlyCaptcha: Unknown message type", body)
+                }
+            } catch {
+                print("FriendlyCaptcha: Failed to decode '\(type)' event: \(error)")
             }
         }
     }

--- a/FriendlyCaptcha/Classes/FriendlyCaptcha.swift
+++ b/FriendlyCaptcha/Classes/FriendlyCaptcha.swift
@@ -334,9 +334,21 @@ class WidgetViewController: UIViewController, WKScriptMessageHandler, WKNavigati
                     handleStateChange(message)
                 default:
                     print("FriendlyCaptcha: Unknown message type", body)
+                    handleError(WidgetErrorEvent(
+                        state: .error,
+                        response: "",
+                        error: WidgetErrorData(code: .other, detail: "Unknown message type: \(body)"),
+                        id: ""
+                    ))
                 }
             } catch {
                 print("FriendlyCaptcha: Failed to decode '\(type)' event: \(error)")
+                handleError(WidgetErrorEvent(
+                    state: .error,
+                    response: "",
+                    error: WidgetErrorData(code: .other, detail: "Failed to decode '\(type)' event: \(error)"),
+                    id: ""
+                ))
             }
         }
     }

--- a/FriendlyCaptcha/Classes/FriendlyCaptcha.swift
+++ b/FriendlyCaptcha/Classes/FriendlyCaptcha.swift
@@ -316,9 +316,9 @@ class WidgetViewController: UIViewController, WKScriptMessageHandler, WKNavigati
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
         if message.name == "bus",
            let body = message.body as? [String: Any],
-           let type = body["type"] as? String,
-           let jsonData = try? JSONSerialization.data(withJSONObject: body["data"] as Any) {
+           let type = body["type"] as? String {
             do {
+                let jsonData = try JSONSerialization.data(withJSONObject: body["data"] as Any, options: .fragmentsAllowed)
                 switch type {
                 case "complete":
                     let message = try JSONDecoder().decode(WidgetCompleteEvent.self, from: jsonData)

--- a/FriendlyCaptcha/Classes/FriendlyCaptchaWidgetEvent.swift
+++ b/FriendlyCaptcha/Classes/FriendlyCaptchaWidgetEvent.swift
@@ -39,6 +39,13 @@ public class WidgetErrorEvent: NSObject, Codable {
 
     /// The ID of the widget from which the event originated.
     public let id: String
+
+    init(state: WidgetState, response: String, error: WidgetErrorData, id: String) {
+        self.state = state
+        self.response = response
+        self.error = error
+        self.id = id
+    }
 }
 
 /// Event that gets dispatched when the widget expires.
@@ -96,6 +103,11 @@ public class WidgetErrorData: NSObject, Codable {
     /// This value is not localized and will change between versions.
     /// You can log it, but make sure not to depend on it in your code.
     public let detail: String
+
+    init(code: WidgetErrorCode, detail: String) {
+        self.code = code
+        self.detail = detail
+    }
 }
 
 /// Error codes that can be returned by the widget.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add the following to the list of dependencies in your `Package.swift`:
 ```
 .package(
     url: "https://github.com/FriendlyCaptcha/friendly-captcha-ios.git",
-    .upToNextMinor(from: "1.0.3")
+    .upToNextMinor(from: "1.0.4")
 )
 ```
 
@@ -25,7 +25,7 @@ Add the following to the list of dependencies in your `Package.swift`:
 Add the following line to your `Cartfile`:
 
 ```
-github "FriendlyCaptcha/friendly-captcha-ios" ~> 1.0.3
+github "FriendlyCaptcha/friendly-captcha-ios" ~> 1.0.4
 ```
 
 ### CocoaPods
@@ -33,7 +33,7 @@ github "FriendlyCaptcha/friendly-captcha-ios" ~> 1.0.3
 Add the following line to your `Podfile`:
 
 ```
-pod 'FriendlyCaptcha', '~> 1.0.3'
+pod 'FriendlyCaptcha', '~> 1.0.4'
 ```
 
 ## Documentation


### PR DESCRIPTION
Avoids `try!` which can crash an application. Opts instead for `do...catch`, which will print an error message but continue running. Our tests should still catch any drift between the JavaScript SDK JSON objects and the shape of the Swift classes into which they are decoded.

Closes #10